### PR TITLE
Rename budget table to budget_entries

### DIFF
--- a/cf-worker/src/db/migrations/0008_budget_to_budget_entries.sql
+++ b/cf-worker/src/db/migrations/0008_budget_to_budget_entries.sql
@@ -1,0 +1,19 @@
+ALTER TABLE `budget` RENAME TO `budget_entries`;--> statement-breakpoint
+DROP INDEX `budget_monthly_query_idx`;--> statement-breakpoint
+DROP INDEX `budget_name_groupid_deleted_added_time_amount_idx`;--> statement-breakpoint
+DROP INDEX `budget_name_groupid_deleted_idx`;--> statement-breakpoint
+DROP INDEX `budget_name_price_idx`;--> statement-breakpoint
+DROP INDEX `budget_name_idx`;--> statement-breakpoint
+DROP INDEX `budget_amount_idx`;--> statement-breakpoint
+DROP INDEX `budget_name_added_time_idx`;--> statement-breakpoint
+DROP INDEX `budget_added_time_idx`;--> statement-breakpoint
+DROP INDEX `budget_budget_id_idx`;--> statement-breakpoint
+CREATE INDEX `budget_entries_monthly_query_idx` ON `budget_entries` (`name`,`groupid`,`deleted`,`added_time`);--> statement-breakpoint
+CREATE INDEX `budget_entries_name_groupid_deleted_added_time_amount_idx` ON `budget_entries` (`name`,`groupid`,`deleted`,`added_time`,`amount`);--> statement-breakpoint
+CREATE INDEX `budget_entries_name_groupid_deleted_idx` ON `budget_entries` (`name`,`groupid`,`deleted`);--> statement-breakpoint
+CREATE INDEX `budget_entries_name_price_idx` ON `budget_entries` (`name`,`price`);--> statement-breakpoint
+CREATE INDEX `budget_entries_name_idx` ON `budget_entries` (`name`);--> statement-breakpoint
+CREATE INDEX `budget_entries_amount_idx` ON `budget_entries` (`amount`);--> statement-breakpoint
+CREATE INDEX `budget_entries_name_added_time_idx` ON `budget_entries` (`name`,`added_time`);--> statement-breakpoint
+CREATE INDEX `budget_entries_added_time_idx` ON `budget_entries` (`added_time`);--> statement-breakpoint
+CREATE INDEX `budget_entries_budget_id_idx` ON `budget_entries` (`budget_id`);

--- a/cf-worker/src/db/migrations/meta/0008_snapshot.json
+++ b/cf-worker/src/db/migrations/meta/0008_snapshot.json
@@ -1,0 +1,1254 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "a592ce24-def7-41c7-aba1-0ae5513dbe65",
+  "prevId": "937a8eed-e7eb-474b-8bd6-c72f4868bcad",
+  "tables": {
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "display_username": {
+          "name": "display_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "groupid": {
+          "name": "groupid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        },
+        "user_username_unique": {
+          "name": "user_username_unique",
+          "columns": [
+            "username"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "budget_entries": {
+      "name": "budget_entries",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "budget_id": {
+          "name": "budget_id",
+          "type": "text(100)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text(100)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "added_time": {
+          "name": "added_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'CURRENT_TIMESTAMP'"
+        },
+        "price": {
+          "name": "price",
+          "type": "text(100)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text(100)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "groupid": {
+          "name": "groupid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'GBP'"
+        }
+      },
+      "indexes": {
+        "budget_entries_monthly_query_idx": {
+          "name": "budget_entries_monthly_query_idx",
+          "columns": [
+            "name",
+            "groupid",
+            "deleted",
+            "added_time"
+          ],
+          "isUnique": false
+        },
+        "budget_entries_name_groupid_deleted_added_time_amount_idx": {
+          "name": "budget_entries_name_groupid_deleted_added_time_amount_idx",
+          "columns": [
+            "name",
+            "groupid",
+            "deleted",
+            "added_time",
+            "amount"
+          ],
+          "isUnique": false
+        },
+        "budget_entries_name_groupid_deleted_idx": {
+          "name": "budget_entries_name_groupid_deleted_idx",
+          "columns": [
+            "name",
+            "groupid",
+            "deleted"
+          ],
+          "isUnique": false
+        },
+        "budget_entries_name_price_idx": {
+          "name": "budget_entries_name_price_idx",
+          "columns": [
+            "name",
+            "price"
+          ],
+          "isUnique": false
+        },
+        "budget_entries_name_idx": {
+          "name": "budget_entries_name_idx",
+          "columns": [
+            "name"
+          ],
+          "isUnique": false
+        },
+        "budget_entries_amount_idx": {
+          "name": "budget_entries_amount_idx",
+          "columns": [
+            "amount"
+          ],
+          "isUnique": false
+        },
+        "budget_entries_name_added_time_idx": {
+          "name": "budget_entries_name_added_time_idx",
+          "columns": [
+            "name",
+            "added_time"
+          ],
+          "isUnique": false
+        },
+        "budget_entries_added_time_idx": {
+          "name": "budget_entries_added_time_idx",
+          "columns": [
+            "added_time"
+          ],
+          "isUnique": false
+        },
+        "budget_entries_budget_id_idx": {
+          "name": "budget_entries_budget_id_idx",
+          "columns": [
+            "budget_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "budget_totals": {
+      "name": "budget_totals",
+      "columns": {
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text(100)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "total_amount": {
+          "name": "total_amount",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "budget_totals_group_name_idx": {
+          "name": "budget_totals_group_name_idx",
+          "columns": [
+            "group_id",
+            "name"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "budget_totals_group_id_name_currency_pk": {
+          "columns": [
+            "group_id",
+            "name",
+            "currency"
+          ],
+          "name": "budget_totals_group_id_name_currency_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "groups": {
+      "name": "groups",
+      "columns": {
+        "groupid": {
+          "name": "groupid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "group_name": {
+          "name": "group_name",
+          "type": "text(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'CURRENT_TIMESTAMP'"
+        },
+        "userids": {
+          "name": "userids",
+          "type": "text(1000)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "budgets": {
+          "name": "budgets",
+          "type": "text(1000)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text(2000)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scheduled_action_history": {
+      "name": "scheduled_action_history",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scheduled_action_id": {
+          "name": "scheduled_action_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action_type": {
+          "name": "action_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "executed_at": {
+          "name": "executed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "execution_status": {
+          "name": "execution_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "workflow_instance_id": {
+          "name": "workflow_instance_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "workflow_status": {
+          "name": "workflow_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "action_data": {
+          "name": "action_data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "result_data": {
+          "name": "result_data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "execution_duration_ms": {
+          "name": "execution_duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "scheduled_action_history_user_executed_idx": {
+          "name": "scheduled_action_history_user_executed_idx",
+          "columns": [
+            "user_id",
+            "executed_at"
+          ],
+          "isUnique": false
+        },
+        "scheduled_action_history_scheduled_action_idx": {
+          "name": "scheduled_action_history_scheduled_action_idx",
+          "columns": [
+            "scheduled_action_id",
+            "executed_at"
+          ],
+          "isUnique": false
+        },
+        "scheduled_action_history_status_idx": {
+          "name": "scheduled_action_history_status_idx",
+          "columns": [
+            "execution_status"
+          ],
+          "isUnique": false
+        },
+        "scheduled_action_history_workflow_instance_idx": {
+          "name": "scheduled_action_history_workflow_instance_idx",
+          "columns": [
+            "workflow_instance_id"
+          ],
+          "isUnique": false
+        },
+        "scheduled_action_history_action_date_unique_idx": {
+          "name": "scheduled_action_history_action_date_unique_idx",
+          "columns": [
+            "scheduled_action_id",
+            "executed_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "scheduled_action_history_scheduled_action_id_scheduled_actions_id_fk": {
+          "name": "scheduled_action_history_scheduled_action_id_scheduled_actions_id_fk",
+          "tableFrom": "scheduled_action_history",
+          "tableTo": "scheduled_actions",
+          "columnsFrom": [
+            "scheduled_action_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "scheduled_action_history_user_id_user_id_fk": {
+          "name": "scheduled_action_history_user_id_user_id_fk",
+          "tableFrom": "scheduled_action_history",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scheduled_actions": {
+      "name": "scheduled_actions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action_type": {
+          "name": "action_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "frequency": {
+          "name": "frequency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action_data": {
+          "name": "action_data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_executed_at": {
+          "name": "last_executed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "next_execution_date": {
+          "name": "next_execution_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "scheduled_actions_user_next_execution_idx": {
+          "name": "scheduled_actions_user_next_execution_idx",
+          "columns": [
+            "user_id",
+            "next_execution_date"
+          ],
+          "isUnique": false
+        },
+        "scheduled_actions_user_active_idx": {
+          "name": "scheduled_actions_user_active_idx",
+          "columns": [
+            "user_id",
+            "is_active"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "scheduled_actions_user_id_user_id_fk": {
+          "name": "scheduled_actions_user_id_user_id_fk",
+          "tableFrom": "scheduled_actions",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "transaction_users": {
+      "name": "transaction_users",
+      "columns": {
+        "transaction_id": {
+          "name": "transaction_id",
+          "type": "text(100)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owed_to_user_id": {
+          "name": "owed_to_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "transaction_users_transaction_group_idx": {
+          "name": "transaction_users_transaction_group_idx",
+          "columns": [
+            "transaction_id",
+            "group_id",
+            "deleted"
+          ],
+          "isUnique": false
+        },
+        "transaction_users_transaction_idx": {
+          "name": "transaction_users_transaction_idx",
+          "columns": [
+            "transaction_id",
+            "deleted"
+          ],
+          "isUnique": false
+        },
+        "transaction_users_group_owed_idx": {
+          "name": "transaction_users_group_owed_idx",
+          "columns": [
+            "group_id",
+            "owed_to_user_id",
+            "deleted"
+          ],
+          "isUnique": false
+        },
+        "transaction_users_group_user_idx": {
+          "name": "transaction_users_group_user_idx",
+          "columns": [
+            "group_id",
+            "user_id",
+            "deleted"
+          ],
+          "isUnique": false
+        },
+        "transaction_users_balances_idx": {
+          "name": "transaction_users_balances_idx",
+          "columns": [
+            "group_id",
+            "deleted",
+            "user_id",
+            "owed_to_user_id",
+            "currency"
+          ],
+          "isUnique": false
+        },
+        "transaction_users_group_id_deleted_idx": {
+          "name": "transaction_users_group_id_deleted_idx",
+          "columns": [
+            "group_id",
+            "deleted"
+          ],
+          "isUnique": false
+        },
+        "transaction_users_user_id_idx": {
+          "name": "transaction_users_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "transaction_users_owed_to_user_id_idx": {
+          "name": "transaction_users_owed_to_user_id_idx",
+          "columns": [
+            "owed_to_user_id"
+          ],
+          "isUnique": false
+        },
+        "transaction_users_group_id_idx": {
+          "name": "transaction_users_group_id_idx",
+          "columns": [
+            "group_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "transaction_users_transaction_id_user_id_owed_to_user_id_pk": {
+          "columns": [
+            "transaction_id",
+            "user_id",
+            "owed_to_user_id"
+          ],
+          "name": "transaction_users_transaction_id_user_id_owed_to_user_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "transactions": {
+      "name": "transactions",
+      "columns": {
+        "transaction_id": {
+          "name": "transaction_id",
+          "type": "text(100)",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'CURRENT_TIMESTAMP'"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "transactions_group_id_deleted_created_at_idx": {
+          "name": "transactions_group_id_deleted_created_at_idx",
+          "columns": [
+            "group_id",
+            "deleted",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "transactions_created_at_idx": {
+          "name": "transactions_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "transactions_group_id_idx": {
+          "name": "transactions_group_id_idx",
+          "columns": [
+            "group_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_balances": {
+      "name": "user_balances",
+      "columns": {
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owed_to_user_id": {
+          "name": "owed_to_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "balance": {
+          "name": "balance",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_balances_group_owed_idx": {
+          "name": "user_balances_group_owed_idx",
+          "columns": [
+            "group_id",
+            "owed_to_user_id",
+            "currency"
+          ],
+          "isUnique": false
+        },
+        "user_balances_group_user_idx": {
+          "name": "user_balances_group_user_idx",
+          "columns": [
+            "group_id",
+            "user_id",
+            "currency"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "user_balances_group_id_user_id_owed_to_user_id_currency_pk": {
+          "columns": [
+            "group_id",
+            "user_id",
+            "owed_to_user_id",
+            "currency"
+          ],
+          "name": "user_balances_group_id_user_id_owed_to_user_id_currency_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {
+      "\"budget\"": "\"budget_entries\""
+    },
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/cf-worker/src/db/migrations/meta/_journal.json
+++ b/cf-worker/src/db/migrations/meta/_journal.json
@@ -1,62 +1,69 @@
 {
-	"version": "7",
-	"dialect": "sqlite",
-	"entries": [
-		{
-			"idx": 0,
-			"version": "6",
-			"when": 1753562098470,
-			"tag": "0000_rich_psylocke",
-			"breakpoints": true
-		},
-		{
-			"idx": 1,
-			"version": "6",
-			"when": 1753714477002,
-			"tag": "0001_volatile_darwin",
-			"breakpoints": true
-		},
-		{
-			"idx": 2,
-			"version": "6",
-			"when": 1753740936582,
-			"tag": "0002_unique_bastion",
-			"breakpoints": true
-		},
-		{
-			"idx": 3,
-			"version": "6",
-			"when": 1754399339381,
-			"tag": "0003_friendly_exodus",
-			"breakpoints": true
-		},
-		{
-			"idx": 4,
-			"version": "6",
-			"when": 1754570877458,
-			"tag": "0004_sleepy_silverclaw",
-			"breakpoints": true
-		},
-		{
-			"idx": 5,
-			"version": "6",
-			"when": 1754572921204,
-			"tag": "0005_natural_chameleon",
-			"breakpoints": true
-		},
-		{
-			"idx": 6,
-			"version": "6",
-			"when": 1755029250923,
-			"tag": "0006_real_lyja",
-			"breakpoints": true
-		},
-		{
-			"idx": 7,
-			"version": "6",
-			"when": 1755250750657,
-			"tag": "0007_make-transaction-id-primary-key",
-			"breakpoints": true
-		}
-	]
+  "version": "7",
+  "dialect": "sqlite",
+  "entries": [
+    {
+      "idx": 0,
+      "version": "6",
+      "when": 1753562098470,
+      "tag": "0000_rich_psylocke",
+      "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "6",
+      "when": 1753714477002,
+      "tag": "0001_volatile_darwin",
+      "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "6",
+      "when": 1753740936582,
+      "tag": "0002_unique_bastion",
+      "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "6",
+      "when": 1754399339381,
+      "tag": "0003_friendly_exodus",
+      "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "6",
+      "when": 1754570877458,
+      "tag": "0004_sleepy_silverclaw",
+      "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "6",
+      "when": 1754572921204,
+      "tag": "0005_natural_chameleon",
+      "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "6",
+      "when": 1755029250923,
+      "tag": "0006_real_lyja",
+      "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "6",
+      "when": 1755250750657,
+      "tag": "0007_make-transaction-id-primary-key",
+      "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "6",
+      "when": 1755452931780,
+      "tag": "0008_budget_to_budget_entries",
+      "breakpoints": true
+    }
+  ]
 }

--- a/cf-worker/src/db/schema/schema.ts
+++ b/cf-worker/src/db/schema/schema.ts
@@ -96,8 +96,8 @@ export const transactionUsers = sqliteTable(
 	],
 );
 
-export const budget = sqliteTable(
-	"budget",
+export const budgetEntries = sqliteTable(
+	"budget_entries",
 	{
 		id: integer("id").primaryKey({ autoIncrement: true }),
 		budgetId: text("budget_id", { length: 100 }), // For deterministic creation in scheduled actions
@@ -111,30 +111,30 @@ export const budget = sqliteTable(
 		currency: text("currency", { length: 10 }).notNull().default("GBP"),
 	},
 	(table) => [
-		index("budget_monthly_query_idx").on(
+		index("budget_entries_monthly_query_idx").on(
 			table.name,
 			table.groupid,
 			table.deleted,
 			table.addedTime,
 		),
-		index("budget_name_groupid_deleted_added_time_amount_idx").on(
+		index("budget_entries_name_groupid_deleted_added_time_amount_idx").on(
 			table.name,
 			table.groupid,
 			table.deleted,
 			table.addedTime,
 			table.amount,
 		),
-		index("budget_name_groupid_deleted_idx").on(
+		index("budget_entries_name_groupid_deleted_idx").on(
 			table.name,
 			table.groupid,
 			table.deleted,
 		),
-		index("budget_name_price_idx").on(table.name, table.price),
-		index("budget_name_idx").on(table.name),
-		index("budget_amount_idx").on(table.amount),
-		index("budget_name_added_time_idx").on(table.name, table.addedTime),
-		index("budget_added_time_idx").on(table.addedTime),
-		index("budget_budget_id_idx").on(table.budgetId),
+		index("budget_entries_name_price_idx").on(table.name, table.price),
+		index("budget_entries_name_idx").on(table.name),
+		index("budget_entries_amount_idx").on(table.amount),
+		index("budget_entries_name_added_time_idx").on(table.name, table.addedTime),
+		index("budget_entries_added_time_idx").on(table.addedTime),
+		index("budget_entries_budget_id_idx").on(table.budgetId),
 	],
 );
 
@@ -287,7 +287,7 @@ export const schema = {
 	verification,
 	transactions,
 	transactionUsers,
-	budget,
+	budgetEntries,
 	userBalances,
 	budgetTotals,
 	scheduledActions,
@@ -305,8 +305,8 @@ export type Transaction = typeof transactions.$inferSelect;
 export type NewTransaction = typeof transactions.$inferInsert;
 export type TransactionUser = typeof transactionUsers.$inferSelect;
 export type NewTransactionUser = typeof transactionUsers.$inferInsert;
-export type Budget = typeof budget.$inferSelect;
-export type NewBudget = typeof budget.$inferInsert;
+export type BudgetEntry = typeof budgetEntries.$inferSelect;
+export type NewBudgetEntry = typeof budgetEntries.$inferInsert;
 export type UserBalance = typeof userBalances.$inferSelect;
 export type NewUserBalance = typeof userBalances.$inferInsert;
 export type BudgetTotal = typeof budgetTotals.$inferSelect;

--- a/cf-worker/src/tests/budget.test.ts
+++ b/cf-worker/src/tests/budget.test.ts
@@ -10,7 +10,7 @@ import type {
 	MonthlyBudget,
 } from "../../../shared-types";
 import { getDb } from "../db";
-import { budget, transactions, transactionUsers } from "../db/schema/schema";
+import { budgetEntries, transactions, transactionUsers } from "../db/schema/schema";
 import worker from "../index";
 import type { UserBalancesByUser } from "../types";
 import {
@@ -1259,7 +1259,7 @@ describe("Budget Handlers", () => {
 			const db = getDb(env);
 
 			// Create a budget entry to delete with correct schema
-			await db.insert(budget).values({
+			await db.insert(budgetEntries).values({
 				id: 1,
 				description: "Test entry",
 				price: "+100.00",
@@ -1306,7 +1306,7 @@ describe("Budget Handlers", () => {
 			const db = getDb(env);
 
 			// Create budget entries with correct schema
-			await db.insert(budget).values({
+			await db.insert(budgetEntries).values({
 				id: 1,
 				description: "Groceries",
 				price: "+100.00",
@@ -1379,7 +1379,7 @@ describe("Budget Handlers", () => {
 			];
 
 			// Create budget entries with negative amounts for monthly totals (different months)
-			await db.insert(budget).values([
+			await db.insert(budgetEntries).values([
 				{
 					description: "Month1 expense",
 					price: "-500.00",
@@ -1627,7 +1627,7 @@ describe("Budget Handlers", () => {
 					.replace(/\.\d{3}Z$/, "");
 			};
 
-			await db.insert(budget).values([
+			await db.insert(budgetEntries).values([
 				{
 					description: "Month 1 expense",
 					price: "-1000.00",
@@ -1789,7 +1789,7 @@ describe("Budget Handlers", () => {
 
 			// Create a comprehensive scenario with mixed amounts across multiple months and currencies
 			// Month 1: +800 USD budget allocation, -250 USD groceries, -150 USD utilities
-			await db.insert(budget).values([
+			await db.insert(budgetEntries).values([
 				{
 					description: "Month1 Budget",
 					price: "+800.00",
@@ -1824,7 +1824,7 @@ describe("Budget Handlers", () => {
 			]);
 
 			// Month 2: +800 USD budget, -300 USD groceries, -200 USD utilities, +50 GBP extra budget, -75 GBP transport
-			await db.insert(budget).values([
+			await db.insert(budgetEntries).values([
 				{
 					description: "Month2 Budget",
 					price: "+800.00",
@@ -1881,7 +1881,7 @@ describe("Budget Handlers", () => {
 			]);
 
 			// Month 3: Only positive amounts (budget allocations), no expenses
-			await db.insert(budget).values([
+			await db.insert(budgetEntries).values([
 				{
 					description: "Month3 Budget",
 					price: "+900.00",
@@ -1905,7 +1905,7 @@ describe("Budget Handlers", () => {
 			]);
 
 			// Month 4: Only negative amounts (expenses), no budget allocations
-			await db.insert(budget).values([
+			await db.insert(budgetEntries).values([
 				{
 					description: "Month4 Groceries",
 					price: "-400.00",
@@ -2136,7 +2136,7 @@ describe("Budget Handlers", () => {
 			];
 
 			// Create scenario where one currency has only positive amounts
-			await db.insert(budget).values([
+			await db.insert(budgetEntries).values([
 				{
 					description: "USD Expense",
 					price: "-500.00",
@@ -2255,7 +2255,7 @@ describe("Budget Handlers", () => {
 			const db = getDb(env);
 
 			// Create budget entries with correct schema
-			await db.insert(budget).values([
+			await db.insert(budgetEntries).values([
 				{
 					description: "Entry 1",
 					price: "+500.00",

--- a/cf-worker/src/tests/scheduled-actions-workflow.test.ts
+++ b/cf-worker/src/tests/scheduled-actions-workflow.test.ts
@@ -9,7 +9,7 @@ import type {
 import { getDb } from "../db";
 import { user } from "../db/schema/auth-schema";
 import {
-	budget,
+	budgetEntries,
 	groups,
 	scheduledActionHistory,
 	scheduledActions,
@@ -1124,8 +1124,8 @@ describe("Scheduled Actions Workflows", () => {
 			// Verify budget was created with the specified ID
 			const budgetResult = await db
 				.select()
-				.from(budget)
-				.where(eq(budget.budgetId, budgetId))
+				.from(budgetEntries)
+				.where(eq(budgetEntries.budgetId, budgetId))
 				.limit(1);
 			expect(budgetResult).toHaveLength(1);
 			expect(budgetResult[0].budgetId).toBe(budgetId);
@@ -1221,8 +1221,8 @@ describe("Scheduled Actions Workflows", () => {
 			// Verify only one budget entry exists
 			const budgetResult = await db
 				.select()
-				.from(budget)
-				.where(eq(budget.budgetId, budgetId));
+				.from(budgetEntries)
+				.where(eq(budgetEntries.budgetId, budgetId));
 			expect(budgetResult).toHaveLength(1);
 		});
 	});
@@ -1430,8 +1430,8 @@ describe("Scheduled Actions Workflows", () => {
 			// Verify results
 			const budgetEntryResult = await db
 				.select()
-				.from(budget)
-				.where(eq(budget.budgetId, budgetId))
+				.from(budgetEntries)
+				.where(eq(budgetEntries.budgetId, budgetId))
 				.limit(1);
 			expect(budgetEntryResult).toHaveLength(1);
 			expect(budgetEntryResult[0].amount).toBe(800);

--- a/cf-worker/src/utils/scheduled-action-execution.ts
+++ b/cf-worker/src/utils/scheduled-action-execution.ts
@@ -9,7 +9,7 @@ import type {
 import type { getDb } from "../db";
 import { user } from "../db/schema/auth-schema";
 import {
-	budget,
+	budgetEntries,
 	budgetTotals,
 	transactions,
 	transactionUsers,
@@ -383,8 +383,8 @@ export async function createBudgetEntryStatements(
 	// Check if budget already exists
 	const existingBudget = await db
 		.select()
-		.from(budget)
-		.where(and(eq(budget.budgetId, budgetId), isNull(budget.deleted)))
+		.from(budgetEntries)
+		.where(and(eq(budgetEntries.budgetId, budgetId), isNull(budgetEntries.deleted)))
 		.limit(1);
 
 	if (existingBudget.length > 0) {
@@ -402,7 +402,7 @@ export async function createBudgetEntryStatements(
 
 	// Create budget entry
 	statements.push({
-		query: db.insert(budget).values({
+		query: db.insert(budgetEntries).values({
 			budgetId,
 			description: budgetRequest.description,
 			addedTime: timestamp,

--- a/cf-worker/todo.md
+++ b/cf-worker/todo.md
@@ -29,6 +29,11 @@
 - history entry on manual run ✅
     - idempotency check ✅
     - insert before calling workflow ✅
+- budget 
+    - budget to budget entries
+    - new table for budget group mapping with budget id as primary key. use this table instead of budgets column in groups
+        - name should be replaced in budgetTotals, scheduled actions
+    - budget entries primary key change
 - edit action, start date should not be mutated ever
 - scan receipt
 - full text search


### PR DESCRIPTION
## Summary
- Renamed `budget` table to `budget_entries` for clarity
- Updated all code references, tests, and migrations
- Preserved all existing functionality and data

## Test plan
- ✅ All tests pass (109 tests)
- ✅ Migration applied successfully to local DB
- ✅ Lint and typecheck pass