### PR TITLE
Make budgetEntryId required and unique

### DIFF
--- a/cf-worker/src/db/migrations/0013_backfill_budget_entry_id.sql
+++ b/cf-worker/src/db/migrations/0013_backfill_budget_entry_id.sql
@@ -1,0 +1,1 @@
+UPDATE `budget_entries` SET `budget_entry_id` = 'bge_' || lower(hex(randomblob(8))) || '_' || `id` WHERE `budget_entry_id` IS NULL;

--- a/cf-worker/src/db/migrations/0014_budget_entry_id_constraints.sql
+++ b/cf-worker/src/db/migrations/0014_budget_entry_id_constraints.sql
@@ -1,0 +1,26 @@
+PRAGMA defer_foreign_keys=ON;--> statement-breakpoint
+CREATE TABLE `__new_budget_entries` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`budget_entry_id` text(100) NOT NULL,
+	`description` text(100) NOT NULL,
+	`added_time` text DEFAULT 'CURRENT_TIMESTAMP' NOT NULL,
+	`price` text(100),
+	`amount` real NOT NULL,
+	`budget_id` text NOT NULL,
+	`deleted` text,
+	`currency` text(10) DEFAULT 'GBP' NOT NULL,
+	FOREIGN KEY (`budget_id`) REFERENCES `group_budgets`(`id`) ON UPDATE no action ON DELETE no action
+);
+--> statement-breakpoint
+INSERT INTO `__new_budget_entries`("id", "budget_entry_id", "description", "added_time", "price", "amount", "budget_id", "deleted", "currency") SELECT "id", "budget_entry_id", "description", "added_time", "price", "amount", "budget_id", "deleted", "currency" FROM `budget_entries`;--> statement-breakpoint
+DROP TABLE `budget_entries`;--> statement-breakpoint
+ALTER TABLE `__new_budget_entries` RENAME TO `budget_entries`;--> statement-breakpoint
+PRAGMA defer_foreign_keys=OFF;--> statement-breakpoint
+CREATE UNIQUE INDEX `budget_entries_budget_entry_id_unique` ON `budget_entries` (`budget_entry_id`);--> statement-breakpoint
+CREATE INDEX `budget_entries_monthly_query_idx` ON `budget_entries` (`budget_id`,`deleted`,`added_time`);--> statement-breakpoint
+CREATE INDEX `budget_entries_budget_id_deleted_added_time_amount_idx` ON `budget_entries` (`budget_id`,`deleted`,`added_time`,`amount`);--> statement-breakpoint
+CREATE INDEX `budget_entries_budget_id_deleted_idx` ON `budget_entries` (`budget_id`,`deleted`);--> statement-breakpoint
+CREATE INDEX `budget_entries_budget_id_idx` ON `budget_entries` (`budget_id`);--> statement-breakpoint
+CREATE INDEX `budget_entries_amount_idx` ON `budget_entries` (`amount`);--> statement-breakpoint
+CREATE INDEX `budget_entries_budget_id_added_time_idx` ON `budget_entries` (`budget_id`,`added_time`);--> statement-breakpoint
+CREATE INDEX `budget_entries_added_time_idx` ON `budget_entries` (`added_time`);

--- a/cf-worker/src/db/migrations/meta/0013_snapshot.json
+++ b/cf-worker/src/db/migrations/meta/0013_snapshot.json
@@ -1,0 +1,1338 @@
+{
+  "id": "959d0f30-7ad5-4503-9ff4-78cadce8d197",
+  "prevId": "3f0d3e29-613e-4981-9719-516042d9ba16",
+  "version": "6",
+  "dialect": "sqlite",
+  "tables": {
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "display_username": {
+          "name": "display_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "groupid": {
+          "name": "groupid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        },
+        "user_username_unique": {
+          "name": "user_username_unique",
+          "columns": [
+            "username"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "budget_entries": {
+      "name": "budget_entries",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "budget_entry_id": {
+          "name": "budget_entry_id",
+          "type": "text(100)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text(100)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "added_time": {
+          "name": "added_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'CURRENT_TIMESTAMP'"
+        },
+        "price": {
+          "name": "price",
+          "type": "text(100)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "budget_id": {
+          "name": "budget_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'GBP'"
+        }
+      },
+      "indexes": {
+        "budget_entries_monthly_query_idx": {
+          "name": "budget_entries_monthly_query_idx",
+          "columns": [
+            "budget_id",
+            "deleted",
+            "added_time"
+          ],
+          "isUnique": false
+        },
+        "budget_entries_budget_id_deleted_added_time_amount_idx": {
+          "name": "budget_entries_budget_id_deleted_added_time_amount_idx",
+          "columns": [
+            "budget_id",
+            "deleted",
+            "added_time",
+            "amount"
+          ],
+          "isUnique": false
+        },
+        "budget_entries_budget_id_deleted_idx": {
+          "name": "budget_entries_budget_id_deleted_idx",
+          "columns": [
+            "budget_id",
+            "deleted"
+          ],
+          "isUnique": false
+        },
+        "budget_entries_budget_id_idx": {
+          "name": "budget_entries_budget_id_idx",
+          "columns": [
+            "budget_id"
+          ],
+          "isUnique": false
+        },
+        "budget_entries_amount_idx": {
+          "name": "budget_entries_amount_idx",
+          "columns": [
+            "amount"
+          ],
+          "isUnique": false
+        },
+        "budget_entries_budget_id_added_time_idx": {
+          "name": "budget_entries_budget_id_added_time_idx",
+          "columns": [
+            "budget_id",
+            "added_time"
+          ],
+          "isUnique": false
+        },
+        "budget_entries_added_time_idx": {
+          "name": "budget_entries_added_time_idx",
+          "columns": [
+            "added_time"
+          ],
+          "isUnique": false
+        },
+        "budget_entries_budget_entry_id_idx": {
+          "name": "budget_entries_budget_entry_id_idx",
+          "columns": [
+            "budget_entry_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "budget_entries_budget_id_group_budgets_id_fk": {
+          "name": "budget_entries_budget_id_group_budgets_id_fk",
+          "tableFrom": "budget_entries",
+          "columnsFrom": [
+            "budget_id"
+          ],
+          "tableTo": "group_budgets",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "budget_totals": {
+      "name": "budget_totals",
+      "columns": {
+        "budget_id": {
+          "name": "budget_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "total_amount": {
+          "name": "total_amount",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "budget_totals_budget_id_idx": {
+          "name": "budget_totals_budget_id_idx",
+          "columns": [
+            "budget_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "budget_totals_budget_id_group_budgets_id_fk": {
+          "name": "budget_totals_budget_id_group_budgets_id_fk",
+          "tableFrom": "budget_totals",
+          "columnsFrom": [
+            "budget_id"
+          ],
+          "tableTo": "group_budgets",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "budget_totals_budget_id_currency_pk": {
+          "columns": [
+            "budget_id",
+            "currency"
+          ],
+          "name": "budget_totals_budget_id_currency_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "group_budgets": {
+      "name": "group_budgets",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "budget_name": {
+          "name": "budget_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'CURRENT_TIMESTAMP'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'CURRENT_TIMESTAMP'"
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "group_budgets_group_id_idx": {
+          "name": "group_budgets_group_id_idx",
+          "columns": [
+            "group_id"
+          ],
+          "isUnique": false
+        },
+        "group_budgets_group_name_active_idx": {
+          "name": "group_budgets_group_name_active_idx",
+          "columns": [
+            "group_id",
+            "budget_name"
+          ],
+          "where": "\"group_budgets\".\"deleted\" is null",
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "group_budgets_group_id_groups_groupid_fk": {
+          "name": "group_budgets_group_id_groups_groupid_fk",
+          "tableFrom": "group_budgets",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "tableTo": "groups",
+          "columnsTo": [
+            "groupid"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "groups": {
+      "name": "groups",
+      "columns": {
+        "groupid": {
+          "name": "groupid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "group_name": {
+          "name": "group_name",
+          "type": "text(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'CURRENT_TIMESTAMP'"
+        },
+        "userids": {
+          "name": "userids",
+          "type": "text(1000)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text(2000)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scheduled_action_history": {
+      "name": "scheduled_action_history",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scheduled_action_id": {
+          "name": "scheduled_action_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action_type": {
+          "name": "action_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "executed_at": {
+          "name": "executed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "execution_status": {
+          "name": "execution_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "workflow_instance_id": {
+          "name": "workflow_instance_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "workflow_status": {
+          "name": "workflow_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "action_data": {
+          "name": "action_data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "result_data": {
+          "name": "result_data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "execution_duration_ms": {
+          "name": "execution_duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "scheduled_action_history_user_executed_idx": {
+          "name": "scheduled_action_history_user_executed_idx",
+          "columns": [
+            "user_id",
+            "executed_at"
+          ],
+          "isUnique": false
+        },
+        "scheduled_action_history_scheduled_action_idx": {
+          "name": "scheduled_action_history_scheduled_action_idx",
+          "columns": [
+            "scheduled_action_id",
+            "executed_at"
+          ],
+          "isUnique": false
+        },
+        "scheduled_action_history_status_idx": {
+          "name": "scheduled_action_history_status_idx",
+          "columns": [
+            "execution_status"
+          ],
+          "isUnique": false
+        },
+        "scheduled_action_history_workflow_instance_idx": {
+          "name": "scheduled_action_history_workflow_instance_idx",
+          "columns": [
+            "workflow_instance_id"
+          ],
+          "isUnique": false
+        },
+        "scheduled_action_history_action_date_unique_idx": {
+          "name": "scheduled_action_history_action_date_unique_idx",
+          "columns": [
+            "scheduled_action_id",
+            "executed_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "scheduled_action_history_scheduled_action_id_scheduled_actions_id_fk": {
+          "name": "scheduled_action_history_scheduled_action_id_scheduled_actions_id_fk",
+          "tableFrom": "scheduled_action_history",
+          "columnsFrom": [
+            "scheduled_action_id"
+          ],
+          "tableTo": "scheduled_actions",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "scheduled_action_history_user_id_user_id_fk": {
+          "name": "scheduled_action_history_user_id_user_id_fk",
+          "tableFrom": "scheduled_action_history",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scheduled_actions": {
+      "name": "scheduled_actions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action_type": {
+          "name": "action_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "frequency": {
+          "name": "frequency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action_data": {
+          "name": "action_data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_executed_at": {
+          "name": "last_executed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "next_execution_date": {
+          "name": "next_execution_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "scheduled_actions_user_next_execution_idx": {
+          "name": "scheduled_actions_user_next_execution_idx",
+          "columns": [
+            "user_id",
+            "next_execution_date"
+          ],
+          "isUnique": false
+        },
+        "scheduled_actions_user_active_idx": {
+          "name": "scheduled_actions_user_active_idx",
+          "columns": [
+            "user_id",
+            "is_active"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "scheduled_actions_user_id_user_id_fk": {
+          "name": "scheduled_actions_user_id_user_id_fk",
+          "tableFrom": "scheduled_actions",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "transaction_users": {
+      "name": "transaction_users",
+      "columns": {
+        "transaction_id": {
+          "name": "transaction_id",
+          "type": "text(100)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owed_to_user_id": {
+          "name": "owed_to_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "transaction_users_transaction_group_idx": {
+          "name": "transaction_users_transaction_group_idx",
+          "columns": [
+            "transaction_id",
+            "group_id",
+            "deleted"
+          ],
+          "isUnique": false
+        },
+        "transaction_users_transaction_idx": {
+          "name": "transaction_users_transaction_idx",
+          "columns": [
+            "transaction_id",
+            "deleted"
+          ],
+          "isUnique": false
+        },
+        "transaction_users_group_owed_idx": {
+          "name": "transaction_users_group_owed_idx",
+          "columns": [
+            "group_id",
+            "owed_to_user_id",
+            "deleted"
+          ],
+          "isUnique": false
+        },
+        "transaction_users_group_user_idx": {
+          "name": "transaction_users_group_user_idx",
+          "columns": [
+            "group_id",
+            "user_id",
+            "deleted"
+          ],
+          "isUnique": false
+        },
+        "transaction_users_balances_idx": {
+          "name": "transaction_users_balances_idx",
+          "columns": [
+            "group_id",
+            "deleted",
+            "user_id",
+            "owed_to_user_id",
+            "currency"
+          ],
+          "isUnique": false
+        },
+        "transaction_users_group_id_deleted_idx": {
+          "name": "transaction_users_group_id_deleted_idx",
+          "columns": [
+            "group_id",
+            "deleted"
+          ],
+          "isUnique": false
+        },
+        "transaction_users_user_id_idx": {
+          "name": "transaction_users_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "transaction_users_owed_to_user_id_idx": {
+          "name": "transaction_users_owed_to_user_id_idx",
+          "columns": [
+            "owed_to_user_id"
+          ],
+          "isUnique": false
+        },
+        "transaction_users_group_id_idx": {
+          "name": "transaction_users_group_id_idx",
+          "columns": [
+            "group_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "transaction_users_transaction_id_user_id_owed_to_user_id_pk": {
+          "columns": [
+            "transaction_id",
+            "user_id",
+            "owed_to_user_id"
+          ],
+          "name": "transaction_users_transaction_id_user_id_owed_to_user_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "transactions": {
+      "name": "transactions",
+      "columns": {
+        "transaction_id": {
+          "name": "transaction_id",
+          "type": "text(100)",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'CURRENT_TIMESTAMP'"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "transactions_group_id_deleted_created_at_idx": {
+          "name": "transactions_group_id_deleted_created_at_idx",
+          "columns": [
+            "group_id",
+            "deleted",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "transactions_created_at_idx": {
+          "name": "transactions_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "transactions_group_id_idx": {
+          "name": "transactions_group_id_idx",
+          "columns": [
+            "group_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_balances": {
+      "name": "user_balances",
+      "columns": {
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owed_to_user_id": {
+          "name": "owed_to_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "balance": {
+          "name": "balance",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_balances_group_owed_idx": {
+          "name": "user_balances_group_owed_idx",
+          "columns": [
+            "group_id",
+            "owed_to_user_id",
+            "currency"
+          ],
+          "isUnique": false
+        },
+        "user_balances_group_user_idx": {
+          "name": "user_balances_group_user_idx",
+          "columns": [
+            "group_id",
+            "user_id",
+            "currency"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "user_balances_group_id_user_id_owed_to_user_id_currency_pk": {
+          "columns": [
+            "group_id",
+            "user_id",
+            "owed_to_user_id",
+            "currency"
+          ],
+          "name": "user_balances_group_id_user_id_owed_to_user_id_currency_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/cf-worker/src/db/migrations/meta/0014_snapshot.json
+++ b/cf-worker/src/db/migrations/meta/0014_snapshot.json
@@ -1,0 +1,1345 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "c6f5a74e-9076-49e8-9525-5467925eb6b4",
+  "prevId": "959d0f30-7ad5-4503-9ff4-78cadce8d197",
+  "tables": {
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "display_username": {
+          "name": "display_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "groupid": {
+          "name": "groupid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        },
+        "user_username_unique": {
+          "name": "user_username_unique",
+          "columns": [
+            "username"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "budget_entries": {
+      "name": "budget_entries",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "budget_entry_id": {
+          "name": "budget_entry_id",
+          "type": "text(100)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text(100)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "added_time": {
+          "name": "added_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'CURRENT_TIMESTAMP'"
+        },
+        "price": {
+          "name": "price",
+          "type": "text(100)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "budget_id": {
+          "name": "budget_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'GBP'"
+        }
+      },
+      "indexes": {
+        "budget_entries_budget_entry_id_unique": {
+          "name": "budget_entries_budget_entry_id_unique",
+          "columns": [
+            "budget_entry_id"
+          ],
+          "isUnique": true
+        },
+        "budget_entries_monthly_query_idx": {
+          "name": "budget_entries_monthly_query_idx",
+          "columns": [
+            "budget_id",
+            "deleted",
+            "added_time"
+          ],
+          "isUnique": false
+        },
+        "budget_entries_budget_id_deleted_added_time_amount_idx": {
+          "name": "budget_entries_budget_id_deleted_added_time_amount_idx",
+          "columns": [
+            "budget_id",
+            "deleted",
+            "added_time",
+            "amount"
+          ],
+          "isUnique": false
+        },
+        "budget_entries_budget_id_deleted_idx": {
+          "name": "budget_entries_budget_id_deleted_idx",
+          "columns": [
+            "budget_id",
+            "deleted"
+          ],
+          "isUnique": false
+        },
+        "budget_entries_budget_id_idx": {
+          "name": "budget_entries_budget_id_idx",
+          "columns": [
+            "budget_id"
+          ],
+          "isUnique": false
+        },
+        "budget_entries_amount_idx": {
+          "name": "budget_entries_amount_idx",
+          "columns": [
+            "amount"
+          ],
+          "isUnique": false
+        },
+        "budget_entries_budget_id_added_time_idx": {
+          "name": "budget_entries_budget_id_added_time_idx",
+          "columns": [
+            "budget_id",
+            "added_time"
+          ],
+          "isUnique": false
+        },
+        "budget_entries_added_time_idx": {
+          "name": "budget_entries_added_time_idx",
+          "columns": [
+            "added_time"
+          ],
+          "isUnique": false
+        },
+        "budget_entries_budget_entry_id_idx": {
+          "name": "budget_entries_budget_entry_id_idx",
+          "columns": [
+            "budget_entry_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "budget_entries_budget_id_group_budgets_id_fk": {
+          "name": "budget_entries_budget_id_group_budgets_id_fk",
+          "tableFrom": "budget_entries",
+          "tableTo": "group_budgets",
+          "columnsFrom": [
+            "budget_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "budget_totals": {
+      "name": "budget_totals",
+      "columns": {
+        "budget_id": {
+          "name": "budget_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "total_amount": {
+          "name": "total_amount",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "budget_totals_budget_id_idx": {
+          "name": "budget_totals_budget_id_idx",
+          "columns": [
+            "budget_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "budget_totals_budget_id_group_budgets_id_fk": {
+          "name": "budget_totals_budget_id_group_budgets_id_fk",
+          "tableFrom": "budget_totals",
+          "tableTo": "group_budgets",
+          "columnsFrom": [
+            "budget_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "budget_totals_budget_id_currency_pk": {
+          "columns": [
+            "budget_id",
+            "currency"
+          ],
+          "name": "budget_totals_budget_id_currency_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "group_budgets": {
+      "name": "group_budgets",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "budget_name": {
+          "name": "budget_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'CURRENT_TIMESTAMP'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'CURRENT_TIMESTAMP'"
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "group_budgets_group_id_idx": {
+          "name": "group_budgets_group_id_idx",
+          "columns": [
+            "group_id"
+          ],
+          "isUnique": false
+        },
+        "group_budgets_group_name_active_idx": {
+          "name": "group_budgets_group_name_active_idx",
+          "columns": [
+            "group_id",
+            "budget_name"
+          ],
+          "isUnique": false,
+          "where": "\"group_budgets\".\"deleted\" is null"
+        }
+      },
+      "foreignKeys": {
+        "group_budgets_group_id_groups_groupid_fk": {
+          "name": "group_budgets_group_id_groups_groupid_fk",
+          "tableFrom": "group_budgets",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "groupid"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "groups": {
+      "name": "groups",
+      "columns": {
+        "groupid": {
+          "name": "groupid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "group_name": {
+          "name": "group_name",
+          "type": "text(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'CURRENT_TIMESTAMP'"
+        },
+        "userids": {
+          "name": "userids",
+          "type": "text(1000)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text(2000)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scheduled_action_history": {
+      "name": "scheduled_action_history",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scheduled_action_id": {
+          "name": "scheduled_action_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action_type": {
+          "name": "action_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "executed_at": {
+          "name": "executed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "execution_status": {
+          "name": "execution_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "workflow_instance_id": {
+          "name": "workflow_instance_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "workflow_status": {
+          "name": "workflow_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "action_data": {
+          "name": "action_data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "result_data": {
+          "name": "result_data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "execution_duration_ms": {
+          "name": "execution_duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "scheduled_action_history_user_executed_idx": {
+          "name": "scheduled_action_history_user_executed_idx",
+          "columns": [
+            "user_id",
+            "executed_at"
+          ],
+          "isUnique": false
+        },
+        "scheduled_action_history_scheduled_action_idx": {
+          "name": "scheduled_action_history_scheduled_action_idx",
+          "columns": [
+            "scheduled_action_id",
+            "executed_at"
+          ],
+          "isUnique": false
+        },
+        "scheduled_action_history_status_idx": {
+          "name": "scheduled_action_history_status_idx",
+          "columns": [
+            "execution_status"
+          ],
+          "isUnique": false
+        },
+        "scheduled_action_history_workflow_instance_idx": {
+          "name": "scheduled_action_history_workflow_instance_idx",
+          "columns": [
+            "workflow_instance_id"
+          ],
+          "isUnique": false
+        },
+        "scheduled_action_history_action_date_unique_idx": {
+          "name": "scheduled_action_history_action_date_unique_idx",
+          "columns": [
+            "scheduled_action_id",
+            "executed_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "scheduled_action_history_scheduled_action_id_scheduled_actions_id_fk": {
+          "name": "scheduled_action_history_scheduled_action_id_scheduled_actions_id_fk",
+          "tableFrom": "scheduled_action_history",
+          "tableTo": "scheduled_actions",
+          "columnsFrom": [
+            "scheduled_action_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "scheduled_action_history_user_id_user_id_fk": {
+          "name": "scheduled_action_history_user_id_user_id_fk",
+          "tableFrom": "scheduled_action_history",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scheduled_actions": {
+      "name": "scheduled_actions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action_type": {
+          "name": "action_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "frequency": {
+          "name": "frequency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action_data": {
+          "name": "action_data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_executed_at": {
+          "name": "last_executed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "next_execution_date": {
+          "name": "next_execution_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "scheduled_actions_user_next_execution_idx": {
+          "name": "scheduled_actions_user_next_execution_idx",
+          "columns": [
+            "user_id",
+            "next_execution_date"
+          ],
+          "isUnique": false
+        },
+        "scheduled_actions_user_active_idx": {
+          "name": "scheduled_actions_user_active_idx",
+          "columns": [
+            "user_id",
+            "is_active"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "scheduled_actions_user_id_user_id_fk": {
+          "name": "scheduled_actions_user_id_user_id_fk",
+          "tableFrom": "scheduled_actions",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "transaction_users": {
+      "name": "transaction_users",
+      "columns": {
+        "transaction_id": {
+          "name": "transaction_id",
+          "type": "text(100)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owed_to_user_id": {
+          "name": "owed_to_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "transaction_users_transaction_group_idx": {
+          "name": "transaction_users_transaction_group_idx",
+          "columns": [
+            "transaction_id",
+            "group_id",
+            "deleted"
+          ],
+          "isUnique": false
+        },
+        "transaction_users_transaction_idx": {
+          "name": "transaction_users_transaction_idx",
+          "columns": [
+            "transaction_id",
+            "deleted"
+          ],
+          "isUnique": false
+        },
+        "transaction_users_group_owed_idx": {
+          "name": "transaction_users_group_owed_idx",
+          "columns": [
+            "group_id",
+            "owed_to_user_id",
+            "deleted"
+          ],
+          "isUnique": false
+        },
+        "transaction_users_group_user_idx": {
+          "name": "transaction_users_group_user_idx",
+          "columns": [
+            "group_id",
+            "user_id",
+            "deleted"
+          ],
+          "isUnique": false
+        },
+        "transaction_users_balances_idx": {
+          "name": "transaction_users_balances_idx",
+          "columns": [
+            "group_id",
+            "deleted",
+            "user_id",
+            "owed_to_user_id",
+            "currency"
+          ],
+          "isUnique": false
+        },
+        "transaction_users_group_id_deleted_idx": {
+          "name": "transaction_users_group_id_deleted_idx",
+          "columns": [
+            "group_id",
+            "deleted"
+          ],
+          "isUnique": false
+        },
+        "transaction_users_user_id_idx": {
+          "name": "transaction_users_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "transaction_users_owed_to_user_id_idx": {
+          "name": "transaction_users_owed_to_user_id_idx",
+          "columns": [
+            "owed_to_user_id"
+          ],
+          "isUnique": false
+        },
+        "transaction_users_group_id_idx": {
+          "name": "transaction_users_group_id_idx",
+          "columns": [
+            "group_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "transaction_users_transaction_id_user_id_owed_to_user_id_pk": {
+          "columns": [
+            "transaction_id",
+            "user_id",
+            "owed_to_user_id"
+          ],
+          "name": "transaction_users_transaction_id_user_id_owed_to_user_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "transactions": {
+      "name": "transactions",
+      "columns": {
+        "transaction_id": {
+          "name": "transaction_id",
+          "type": "text(100)",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'CURRENT_TIMESTAMP'"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "transactions_group_id_deleted_created_at_idx": {
+          "name": "transactions_group_id_deleted_created_at_idx",
+          "columns": [
+            "group_id",
+            "deleted",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "transactions_created_at_idx": {
+          "name": "transactions_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "transactions_group_id_idx": {
+          "name": "transactions_group_id_idx",
+          "columns": [
+            "group_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_balances": {
+      "name": "user_balances",
+      "columns": {
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owed_to_user_id": {
+          "name": "owed_to_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "balance": {
+          "name": "balance",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_balances_group_owed_idx": {
+          "name": "user_balances_group_owed_idx",
+          "columns": [
+            "group_id",
+            "owed_to_user_id",
+            "currency"
+          ],
+          "isUnique": false
+        },
+        "user_balances_group_user_idx": {
+          "name": "user_balances_group_user_idx",
+          "columns": [
+            "group_id",
+            "user_id",
+            "currency"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "user_balances_group_id_user_id_owed_to_user_id_currency_pk": {
+          "columns": [
+            "group_id",
+            "user_id",
+            "owed_to_user_id",
+            "currency"
+          ],
+          "name": "user_balances_group_id_user_id_owed_to_user_id_currency_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/cf-worker/src/db/migrations/meta/_journal.json
+++ b/cf-worker/src/db/migrations/meta/_journal.json
@@ -1,97 +1,111 @@
 {
-	"version": "7",
-	"dialect": "sqlite",
-	"entries": [
-		{
-			"idx": 0,
-			"version": "6",
-			"when": 1753562098470,
-			"tag": "0000_rich_psylocke",
-			"breakpoints": true
-		},
-		{
-			"idx": 1,
-			"version": "6",
-			"when": 1753714477002,
-			"tag": "0001_volatile_darwin",
-			"breakpoints": true
-		},
-		{
-			"idx": 2,
-			"version": "6",
-			"when": 1753740936582,
-			"tag": "0002_unique_bastion",
-			"breakpoints": true
-		},
-		{
-			"idx": 3,
-			"version": "6",
-			"when": 1754399339381,
-			"tag": "0003_friendly_exodus",
-			"breakpoints": true
-		},
-		{
-			"idx": 4,
-			"version": "6",
-			"when": 1754570877458,
-			"tag": "0004_sleepy_silverclaw",
-			"breakpoints": true
-		},
-		{
-			"idx": 5,
-			"version": "6",
-			"when": 1754572921204,
-			"tag": "0005_natural_chameleon",
-			"breakpoints": true
-		},
-		{
-			"idx": 6,
-			"version": "6",
-			"when": 1755029250923,
-			"tag": "0006_real_lyja",
-			"breakpoints": true
-		},
-		{
-			"idx": 7,
-			"version": "6",
-			"when": 1755250750657,
-			"tag": "0007_make-transaction-id-primary-key",
-			"breakpoints": true
-		},
-		{
-			"idx": 8,
-			"version": "6",
-			"when": 1755452931780,
-			"tag": "0008_budget_to_budget_entries",
-			"breakpoints": true
-		},
-		{
-			"idx": 9,
-			"version": "6",
-			"when": 1755463994299,
-			"tag": "0009_rename-budget-id-to-budget-entry-id",
-			"breakpoints": true
-		},
-		{
-			"idx": 10,
-			"version": "6",
-			"when": 1755508981444,
-			"tag": "0010_eager_scorpion",
-			"breakpoints": true
-		},
-		{
-			"idx": 11,
-			"version": "6",
-			"when": 1755515538068,
-			"tag": "0011_drop-budgets-column",
-			"breakpoints": true
-		},
-		{
-			"idx": 12,
-			"version": "6",
-			"when": 1755642153060,
-			"tag": "0012_demonic_iron_patriot",
-			"breakpoints": true
-		}
-	]
+  "version": "7",
+  "dialect": "sqlite",
+  "entries": [
+    {
+      "idx": 0,
+      "version": "6",
+      "when": 1753562098470,
+      "tag": "0000_rich_psylocke",
+      "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "6",
+      "when": 1753714477002,
+      "tag": "0001_volatile_darwin",
+      "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "6",
+      "when": 1753740936582,
+      "tag": "0002_unique_bastion",
+      "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "6",
+      "when": 1754399339381,
+      "tag": "0003_friendly_exodus",
+      "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "6",
+      "when": 1754570877458,
+      "tag": "0004_sleepy_silverclaw",
+      "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "6",
+      "when": 1754572921204,
+      "tag": "0005_natural_chameleon",
+      "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "6",
+      "when": 1755029250923,
+      "tag": "0006_real_lyja",
+      "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "6",
+      "when": 1755250750657,
+      "tag": "0007_make-transaction-id-primary-key",
+      "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "6",
+      "when": 1755452931780,
+      "tag": "0008_budget_to_budget_entries",
+      "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "6",
+      "when": 1755463994299,
+      "tag": "0009_rename-budget-id-to-budget-entry-id",
+      "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "6",
+      "when": 1755508981444,
+      "tag": "0010_eager_scorpion",
+      "breakpoints": true
+    },
+    {
+      "idx": 11,
+      "version": "6",
+      "when": 1755515538068,
+      "tag": "0011_drop-budgets-column",
+      "breakpoints": true
+    },
+    {
+      "idx": 12,
+      "version": "6",
+      "when": 1755642153060,
+      "tag": "0012_demonic_iron_patriot",
+      "breakpoints": true
+    },
+    {
+      "idx": 13,
+      "version": "6",
+      "when": 1756289496267,
+      "tag": "0013_backfill_budget_entry_id",
+      "breakpoints": true
+    },
+    {
+      "idx": 14,
+      "version": "6",
+      "when": 1756290838383,
+      "tag": "0014_budget_entry_id_constraints",
+      "breakpoints": true
+    }
+  ]
 }

--- a/cf-worker/src/db/schema/schema.ts
+++ b/cf-worker/src/db/schema/schema.ts
@@ -121,7 +121,7 @@ export const budgetEntries = sqliteTable(
 	"budget_entries",
 	{
 		id: integer("id").primaryKey({ autoIncrement: true }),
-		budgetEntryId: text("budget_entry_id", { length: 100 }), // For deterministic creation in scheduled actions
+		budgetEntryId: text("budget_entry_id", { length: 100 }).notNull().unique(), // For deterministic creation in scheduled actions
 		description: text("description", { length: 100 }).notNull(),
 		addedTime: text("added_time").notNull().default("CURRENT_TIMESTAMP"),
 		price: text("price", { length: 100 }),

--- a/cf-worker/src/handlers/budget.ts
+++ b/cf-worker/src/handlers/budget.ts
@@ -245,7 +245,7 @@ async function createBudgetEntry(
 ) {
 	try {
 		// Generate unique budget ID using ULID for regular handler
-		const budgetId = `budget_${ulid()}`;
+		const budgetId = `bge_${ulid()}`;
 
 		// Use the reusable utility function
 		const result = await createBudgetEntryStatements(

--- a/cf-worker/src/tests/budget.test.ts
+++ b/cf-worker/src/tests/budget.test.ts
@@ -1262,7 +1262,7 @@ describe("Budget Handlers", () => {
 
 			// Create a budget entry to delete with correct schema
 			await db.insert(budgetEntries).values({
-				id: 1,
+				budgetEntryId: "bge_test_delete_entry",
 				description: "Test entry",
 				price: "+100.00",
 				addedTime: "2024-01-01 00:00:00",
@@ -1308,7 +1308,7 @@ describe("Budget Handlers", () => {
 
 			// Create budget entries with correct schema
 			await db.insert(budgetEntries).values({
-				id: 1,
+				budgetEntryId: "bge_test_list_entry",
 				description: "Groceries",
 				price: "+100.00",
 				addedTime: "2024-01-01 00:00:00",
@@ -1381,6 +1381,7 @@ describe("Budget Handlers", () => {
 			// Create budget entries with negative amounts for monthly totals (different months)
 			await db.insert(budgetEntries).values([
 				{
+					budgetEntryId: "bge_test_month1_expense",
 					description: "Month1 expense",
 					price: "-500.00",
 					addedTime: formatDate(month1),
@@ -1389,6 +1390,7 @@ describe("Budget Handlers", () => {
 					currency: "USD",
 				},
 				{
+					budgetEntryId: "bge_test_month2_expense",
 					description: "Month2 expense",
 					price: "-600.00",
 					addedTime: formatDate(month2),
@@ -1397,6 +1399,7 @@ describe("Budget Handlers", () => {
 					currency: "USD",
 				},
 				{
+					budgetEntryId: "bge_test_month3_expense",
 					description: "Month3 expense",
 					price: "-400.00",
 					addedTime: formatDate(month3),
@@ -1626,6 +1629,7 @@ describe("Budget Handlers", () => {
 
 			await db.insert(budgetEntries).values([
 				{
+					budgetEntryId: "bge_test_average_month1",
 					description: "Month 1 expense",
 					price: "-1000.00",
 					addedTime: getRecentDate(5),
@@ -1634,6 +1638,7 @@ describe("Budget Handlers", () => {
 					currency: "USD",
 				},
 				{
+					budgetEntryId: "bge_test_average_month2",
 					description: "Month 2 expense",
 					price: "-1200.00",
 					addedTime: getRecentDate(4),
@@ -1642,6 +1647,7 @@ describe("Budget Handlers", () => {
 					currency: "USD",
 				},
 				{
+					budgetEntryId: "bge_test_average_month3",
 					description: "Month 3 expense",
 					price: "-800.00",
 					addedTime: getRecentDate(3),
@@ -1650,6 +1656,7 @@ describe("Budget Handlers", () => {
 					currency: "USD",
 				},
 				{
+					budgetEntryId: "bge_test_average_month4",
 					description: "Month 4 expense",
 					price: "-1100.00",
 					addedTime: getRecentDate(2),
@@ -1658,6 +1665,7 @@ describe("Budget Handlers", () => {
 					currency: "USD",
 				},
 				{
+					budgetEntryId: "bge_test_average_month5",
 					description: "Month 5 expense",
 					price: "-900.00",
 					addedTime: getRecentDate(1),
@@ -1666,6 +1674,7 @@ describe("Budget Handlers", () => {
 					currency: "USD",
 				},
 				{
+					budgetEntryId: "bge_test_average_month6",
 					description: "Month 6 expense",
 					price: "-1300.00",
 					addedTime: getRecentDate(0),
@@ -1782,6 +1791,7 @@ describe("Budget Handlers", () => {
 			// Month 1: +800 USD budget allocation, -250 USD groceries, -150 USD utilities
 			await db.insert(budgetEntries).values([
 				{
+					budgetEntryId: "bge_test_scenario_month1_budget",
 					description: "Month1 Budget",
 					price: "+800.00",
 					addedTime: formatDate(month1),
@@ -1790,6 +1800,7 @@ describe("Budget Handlers", () => {
 					currency: "USD",
 				},
 				{
+					budgetEntryId: "bge_test_scenario_month1_groceries",
 					description: "Groceries",
 					price: "-250.00",
 					addedTime: formatDate(
@@ -1800,6 +1811,7 @@ describe("Budget Handlers", () => {
 					currency: "USD",
 				},
 				{
+					budgetEntryId: "bge_test_scenario_month1_utilities",
 					description: "Utilities",
 					price: "-150.00",
 					addedTime: formatDate(
@@ -1814,6 +1826,7 @@ describe("Budget Handlers", () => {
 			// Month 2: +800 USD budget, -300 USD groceries, -200 USD utilities, +50 GBP extra budget, -75 GBP transport
 			await db.insert(budgetEntries).values([
 				{
+					budgetEntryId: "bge_test_scenario_month2_budget",
 					description: "Month2 Budget",
 					price: "+800.00",
 					addedTime: formatDate(month2),
@@ -1822,6 +1835,7 @@ describe("Budget Handlers", () => {
 					currency: "USD",
 				},
 				{
+					budgetEntryId: "bge_test_scenario_month2_groceries",
 					description: "Groceries Month2",
 					price: "-300.00",
 					addedTime: formatDate(
@@ -1832,6 +1846,7 @@ describe("Budget Handlers", () => {
 					currency: "USD",
 				},
 				{
+					budgetEntryId: "bge_test_scenario_month2_utilities",
 					description: "Utilities Month2",
 					price: "-200.00",
 					addedTime: formatDate(
@@ -1842,6 +1857,7 @@ describe("Budget Handlers", () => {
 					currency: "USD",
 				},
 				{
+					budgetEntryId: "bge_test_scenario_month2_extra_gbp",
 					description: "Extra Budget GBP",
 					price: "+50.00",
 					addedTime: formatDate(
@@ -1852,6 +1868,7 @@ describe("Budget Handlers", () => {
 					currency: "GBP",
 				},
 				{
+					budgetEntryId: "bge_test_scenario_month2_transport",
 					description: "Transport",
 					price: "-75.00",
 					addedTime: formatDate(
@@ -1866,6 +1883,7 @@ describe("Budget Handlers", () => {
 			// Month 3: Only positive amounts (budget allocations), no expenses
 			await db.insert(budgetEntries).values([
 				{
+					budgetEntryId: "bge_test_month3_budget",
 					description: "Month3 Budget",
 					price: "+900.00",
 					addedTime: formatDate(month3),
@@ -1874,6 +1892,7 @@ describe("Budget Handlers", () => {
 					currency: "USD",
 				},
 				{
+					budgetEntryId: "bge_test_month3_bonus",
 					description: "Month3 Bonus",
 					price: "+100.00",
 					addedTime: formatDate(
@@ -1888,6 +1907,7 @@ describe("Budget Handlers", () => {
 			// Month 4: Only negative amounts (expenses), no budget allocations
 			await db.insert(budgetEntries).values([
 				{
+					budgetEntryId: "bge_test_month4_groceries",
 					description: "Month4 Groceries",
 					price: "-400.00",
 					addedTime: formatDate(month4),
@@ -1896,6 +1916,7 @@ describe("Budget Handlers", () => {
 					currency: "USD",
 				},
 				{
+					budgetEntryId: "bge_test_month4_utilities",
 					description: "Month4 Utilities",
 					price: "-180.00",
 					addedTime: formatDate(
@@ -1906,6 +1927,7 @@ describe("Budget Handlers", () => {
 					currency: "USD",
 				},
 				{
+					budgetEntryId: "bge_test_month4_transport",
 					description: "Month4 Transport",
 					price: "-60.00",
 					addedTime: formatDate(
@@ -2116,6 +2138,7 @@ describe("Budget Handlers", () => {
 			// Create scenario where one currency has only positive amounts
 			await db.insert(budgetEntries).values([
 				{
+					budgetEntryId: "bge_test_usd_expense",
 					description: "USD Expense",
 					price: "-500.00",
 					addedTime: formatDate(testMonth),
@@ -2124,6 +2147,7 @@ describe("Budget Handlers", () => {
 					currency: "USD",
 				},
 				{
+					budgetEntryId: "bge_test_gbp_budget",
 					description: "GBP Budget Only",
 					price: "+100.00",
 					addedTime: formatDate(
@@ -2233,6 +2257,7 @@ describe("Budget Handlers", () => {
 			// Create budget entries with correct schema
 			await db.insert(budgetEntries).values([
 				{
+					budgetEntryId: "bge_test_total_entry1",
 					description: "Entry 1",
 					price: "+500.00",
 					addedTime: "2024-01-01 00:00:00",
@@ -2241,6 +2266,7 @@ describe("Budget Handlers", () => {
 					currency: "USD",
 				},
 				{
+					budgetEntryId: "bge_test_total_entry2",
 					description: "Entry 2",
 					price: "+1000.00",
 					addedTime: "2024-02-01 00:00:00",

--- a/cf-worker/src/tests/scheduled-actions-workflow.test.ts
+++ b/cf-worker/src/tests/scheduled-actions-workflow.test.ts
@@ -1122,7 +1122,7 @@ describe("Scheduled Actions Workflows", () => {
 			const id2 = generateDeterministicBudgetId(actionId, date);
 
 			expect(id1).toBe(id2);
-			expect(id1).toBe(`bg_${actionId}_${date}`);
+			expect(id1).toBe(`bge_${actionId}_${date}`);
 		});
 
 		it("should create split transaction statements with deterministic ID", async () => {

--- a/cf-worker/src/utils/scheduled-action-execution.ts
+++ b/cf-worker/src/utils/scheduled-action-execution.ts
@@ -44,7 +44,7 @@ export function generateDeterministicBudgetId(
 	actionId: string,
 	currentDate: string,
 ): string {
-	return `bg_${actionId}_${currentDate}`;
+	return `bge_${actionId}_${currentDate}`;
 }
 
 // Helper function to validate split request

--- a/cf-worker/todo.md
+++ b/cf-worker/todo.md
@@ -32,10 +32,11 @@
 - budget 
     - budget to budget entries ✅
     - new table for budget group mapping with budget id as primary key. use this table instead of budgets column in groups
-        - name should be replaced in budgetTotals, scheduled actions
-    - replace name in budget entry
-    - replace name in scheduled actions
-    - replace name in budget totals
+        - name should be replaced in budgetTotals, scheduled actions ✅
+    - replace name in budget entry ✅
+    - replace name in scheduled actions ✅
+    - replace name in budget totals ✅
+    - backfill null budget entry ids ✅
     - budget entries primary key change
 - edit action, start date should not be mutated ever
 - scan receipt


### PR DESCRIPTION
## Summary
- Backfill null budget_entry_id values with bge_ prefix
- Add NOT NULL and UNIQUE constraints to budgetEntryId field
- Update all budget entry ID generation to use consistent bge_ prefix

## Changes
- Migration 0013: Backfill null budget_entry_id values using SQLite randomblob
- Migration 0014: Add NOT NULL UNIQUE constraint with D1-compatible table recreation
- Updated schema to make budgetEntryId required and unique
- Fixed budget ID generation in handlers and scheduled actions to use bge_ prefix
- Updated all test files to include required budgetEntryId fields

## Test Results
All 178 tests passing with zero linting errors