### PR TITLE
Log allowlisted signup failures and tighten signup UI

### DIFF
--- a/cf-worker/src/handlers/signup.ts
+++ b/cf-worker/src/handlers/signup.ts
@@ -34,6 +34,42 @@ function normalizeIdentity(value: string): string {
 	return value.trim().toLowerCase();
 }
 
+function maskEmail(value: string): string {
+	const normalized = normalizeIdentity(value);
+	const [localPart, domain] = normalized.split("@");
+	if (!localPart || !domain) {
+		return "<invalid-email>";
+	}
+
+	const prefix = localPart.slice(0, 2);
+	return `${prefix}${localPart.length > 2 ? "***" : "*"}@${domain}`;
+}
+
+function logSignupAllowlistError(body: SignupBody, error: unknown): void {
+	console.error("Allowlisted signup rejected: allowlist check failed", {
+		email: maskEmail(body.email),
+		username: normalizeIdentity(body.username),
+		reason: error instanceof Error ? error.message : "Unknown allowlist error",
+	});
+}
+
+function getSignupAllowlistEntry(
+	body: SignupBody,
+	env: Env,
+): SignupAllowlistEntry | null {
+	const allowlist = parseSignupAllowlist(env.SIGNUP_ALLOWLIST_JSON);
+	const entry = findAllowlistEntry(allowlist, body);
+	if (!entry) {
+		console.warn("Allowlisted signup rejected: no matching entry", {
+			email: maskEmail(body.email),
+			username: normalizeIdentity(body.username),
+			allowlistCount: allowlist.length,
+		});
+	}
+
+	return entry;
+}
+
 function requireStringField(
 	entry: Record<string, unknown>,
 	field: keyof SignupAllowlistEntry,
@@ -45,7 +81,9 @@ function requireStringField(
 	return value.trim();
 }
 
-export function parseSignupAllowlist(json: string | undefined): SignupAllowlistEntry[] {
+export function parseSignupAllowlist(
+	json: string | undefined,
+): SignupAllowlistEntry[] {
 	if (!json) {
 		throw new Error("Signup allowlist is missing");
 	}
@@ -93,7 +131,9 @@ export function findAllowlistEntry(
 	return matches[0] ?? null;
 }
 
-export function calculateEqualShares(userIds: string[]): Record<string, number> {
+export function calculateEqualShares(
+	userIds: string[],
+): Record<string, number> {
 	const uniqueSortedIds = Array.from(new Set(userIds)).sort();
 	if (uniqueSortedIds.length === 0) {
 		return {};
@@ -121,7 +161,9 @@ function parseJsonObject(value: string | null): Record<string, unknown> {
 
 	try {
 		const parsed = JSON.parse(value);
-		return parsed !== null && typeof parsed === "object" && !Array.isArray(parsed)
+		return parsed !== null &&
+			typeof parsed === "object" &&
+			!Array.isArray(parsed)
 			? (parsed as Record<string, unknown>)
 			: {};
 	} catch {
@@ -194,7 +236,9 @@ async function getActiveBudgetNames(
 	const rows = await db
 		.select({ budgetName: groupBudgets.budgetName })
 		.from(groupBudgets)
-		.where(and(eq(groupBudgets.groupId, groupId), isNull(groupBudgets.deleted)));
+		.where(
+			and(eq(groupBudgets.groupId, groupId), isNull(groupBudgets.deleted)),
+		);
 
 	return new Set(rows.map((row) => row.budgetName));
 }
@@ -210,7 +254,9 @@ export async function reconcileSignupProvisioning(
 		.limit(1);
 
 	const currentMembers = parseUserIds(existingGroup?.userids ?? null);
-	const nextMembers = Array.from(new Set([...currentMembers, input.userId])).sort();
+	const nextMembers = Array.from(
+		new Set([...currentMembers, input.userId]),
+	).sort();
 	const currentMetadata = parseJsonObject(existingGroup?.metadata ?? null);
 	const nextMetadata = {
 		...currentMetadata,
@@ -403,7 +449,10 @@ async function resumeIncompleteSignup(
 		.select({ id: account.id })
 		.from(account)
 		.where(
-			and(eq(account.userId, existingUser.id), eq(account.providerId, "credential")),
+			and(
+				eq(account.userId, existingUser.id),
+				eq(account.providerId, "credential"),
+			),
 		)
 		.limit(1);
 	if (!credentialAccount) {
@@ -441,11 +490,9 @@ export async function handleAllowlistedSignup(
 
 	let entry: SignupAllowlistEntry | null;
 	try {
-		entry = findAllowlistEntry(
-			parseSignupAllowlist(env.SIGNUP_ALLOWLIST_JSON),
-			body,
-		);
-	} catch {
+		entry = getSignupAllowlistEntry(body, env);
+	} catch (error) {
+		logSignupAllowlistError(body, error);
 		return createErrorResponse("Signup not allowed", 403, request, env);
 	}
 
@@ -463,7 +510,13 @@ export async function handleAllowlistedSignup(
 			body.username,
 		);
 		if (existingUser) {
-			return await resumeIncompleteSignup(db, existingUser, entry, request, env);
+			return await resumeIncompleteSignup(
+				db,
+				existingUser,
+				entry,
+				request,
+				env,
+			);
 		}
 	} catch {
 		return accountExistsResponse(request, env);

--- a/src/pages/SignUp/index.css
+++ b/src/pages/SignUp/index.css
@@ -5,28 +5,36 @@
 	justify-content: center;
 	align-items: center;
 	min-height: 100vh;
+	background: var(--color-light);
 	padding: var(--spacing-medium);
+	box-sizing: border-box;
 }
 
 .signup-form {
+	display: flex;
+	flex-direction: column;
+	gap: 0.75rem;
 	background: var(--color-white);
 	padding: var(--spacing-large);
-	border-radius: var(--border-radius);
+	border-radius: calc(var(--border-radius) * 2);
 	box-shadow: var(--shadow-medium);
 	width: 100%;
-	max-width: 400px;
+	max-width: 420px;
+	box-sizing: border-box;
 }
 
 .signup-title {
 	color: var(--color-dark);
-	margin-bottom: var(--spacing-large);
+	font-size: 1.75rem;
+	line-height: 1.2;
+	margin: 0 0 var(--spacing-small);
 	text-align: center;
 }
 
 .signup-error {
 	color: var(--color-danger);
 	font-size: var(--font-size-small);
-	margin: var(--spacing-small) 0;
+	margin: 0;
 	padding: var(--spacing-small);
 	background: rgba(220, 53, 69, 0.1);
 	border-radius: var(--border-radius);
@@ -45,7 +53,8 @@
 
 .signup-link {
 	text-align: center;
-	margin-top: var(--spacing-medium);
+	margin: var(--spacing-small) 0 0;
+	color: var(--color-dark);
 }
 
 .signup-link a {
@@ -72,13 +81,36 @@
 	pointer-events: none;
 }
 
+.signup-form button {
+	width: 100%;
+	font-weight: 600;
+}
+
 /* Mobile responsiveness */
 @media (max-width: 768px) {
 	.signup-container {
 		padding: var(--spacing-small);
+		align-items: flex-start;
+		padding-top: 8vh;
 	}
 
 	.signup-form {
 		padding: var(--spacing-medium);
+		max-width: 100%;
+	}
+
+	.signup-title {
+		font-size: 1.5rem;
+	}
+}
+
+@media (max-width: 480px) {
+	.signup-container {
+		padding: 12px;
+		padding-top: 6vh;
+	}
+
+	.signup-form {
+		gap: var(--spacing-small);
 	}
 }


### PR DESCRIPTION
## Summary
- add server-side logs for allowlist parse/check failures without logging passwords or full emails
- tighten the /signup form spacing and title scale
- make the Create Account button match the input width

## Verification
- yarn lint
- cd cf-worker && yarn lint
- cd cf-worker && yarn vitest run src/tests/signup.test.ts --no-file-parallelism
- Playwright visual check of /signup at desktop and mobile widths