### PR TITLE
Fix signup D1 upsert conflict targets

### DIFF
--- a/cf-worker/src/handlers/signup.ts
+++ b/cf-worker/src/handlers/signup.ts
@@ -199,7 +199,7 @@ async function ensureSignupGroupExists(
 			userids: "[]",
 			metadata: JSON.stringify({ defaultCurrency: "GBP", defaultShare: {} }),
 		})
-		.onConflictDoNothing();
+		.onConflictDoNothing({ target: groups.groupid });
 }
 
 async function getExistingSignupUser(
@@ -279,7 +279,7 @@ export async function reconcileSignupProvisioning(
 				userids: JSON.stringify(nextMembers),
 				metadata: JSON.stringify(nextMetadata),
 			})
-			.onConflictDoNothing(),
+			.onConflictDoNothing({ target: groups.groupid }),
 	);
 
 	statements.push(
@@ -304,7 +304,7 @@ export async function reconcileSignupProvisioning(
 						createdAt: currentTime,
 						updatedAt: currentTime,
 					})
-					.onConflictDoNothing(),
+					.onConflictDoNothing({ target: groupBudgets.id }),
 			);
 		}
 	}


### PR DESCRIPTION
## Summary
- target D1 upserts for signup-created groups by group primary key
- target default budget inserts by budget primary key
- fixes production signup failures after allowlist matching when creating a new group

## Verification
- cd cf-worker && yarn lint
- cd cf-worker && yarn vitest run src/tests/signup.test.ts --no-file-parallelism