### PR TITLE
Fix groups created_at default

### DIFF
--- a/cf-worker/src/db/migrations/0021_fix_groups_created_at_default.sql
+++ b/cf-worker/src/db/migrations/0021_fix_groups_created_at_default.sql
@@ -1,0 +1,45 @@
+PRAGMA defer_foreign_keys=ON;--> statement-breakpoint
+
+CREATE TABLE `__new_groups` (
+	`groupid` text PRIMARY KEY NOT NULL,
+	`group_name` text(50) NOT NULL,
+	`created_at` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`userids` text(1000),
+	`metadata` text(2000)
+);--> statement-breakpoint
+
+INSERT INTO `__new_groups`("groupid", "group_name", "created_at", "userids", "metadata")
+	SELECT
+		g."groupid",
+		g."group_name",
+		CASE
+			WHEN g."created_at" = 'CURRENT_TIMESTAMP' THEN COALESCE(
+				(
+					SELECT datetime(
+						CASE
+							WHEN MIN(u."created_at") > 9999999999 THEN MIN(u."created_at") / 1000
+							ELSE MIN(u."created_at")
+						END,
+						'unixepoch'
+					)
+					FROM `user` u
+					INNER JOIN json_each(
+						CASE
+							WHEN json_valid(g."userids") THEN g."userids"
+							ELSE '[]'
+						END
+					) member
+						ON member.value = u."id"
+				),
+				CURRENT_TIMESTAMP
+			)
+			ELSE g."created_at"
+		END,
+		g."userids",
+		g."metadata"
+	FROM `groups` g;--> statement-breakpoint
+
+DROP TABLE `groups`;--> statement-breakpoint
+ALTER TABLE `__new_groups` RENAME TO `groups`;--> statement-breakpoint
+
+PRAGMA defer_foreign_keys=OFF;

--- a/cf-worker/src/db/migrations/meta/_journal.json
+++ b/cf-worker/src/db/migrations/meta/_journal.json
@@ -148,6 +148,13 @@
 			"when": 1779616800000,
 			"tag": "0020_repair_groupid_text_schema",
 			"breakpoints": true
+		},
+		{
+			"idx": 21,
+			"version": "6",
+			"when": 1779623400000,
+			"tag": "0021_fix_groups_created_at_default",
+			"breakpoints": true
 		}
 	]
 }

--- a/cf-worker/src/db/schema/schema.ts
+++ b/cf-worker/src/db/schema/schema.ts
@@ -7,7 +7,7 @@ import {
 	text,
 	uniqueIndex,
 } from "drizzle-orm/sqlite-core";
-import { isNull } from "drizzle-orm";
+import { isNull, sql } from "drizzle-orm";
 import type {
 	ScheduledActionData,
 	ScheduledActionResultData,
@@ -18,7 +18,7 @@ import { account, session, user, verification } from "./auth-schema";
 export const groups = sqliteTable("groups", {
 	groupid: text("groupid").primaryKey(),
 	groupName: text("group_name", { length: 50 }).notNull(),
-	createdAt: text("created_at").notNull().default("CURRENT_TIMESTAMP"),
+	createdAt: text("created_at").notNull().default(sql`CURRENT_TIMESTAMP`),
 	userids: text("userids", { length: 1000 }),
 	metadata: text("metadata", { length: 2000 }),
 });


### PR DESCRIPTION
## Summary
- fix Drizzle groups.createdAt to use SQL CURRENT_TIMESTAMP instead of a quoted string literal
- add migration 0021 to rebuild groups with the correct default
- repair existing groups where created_at is the literal CURRENT_TIMESTAMP using the earliest member user.created_at, falling back to current timestamp

## Verification
- npx wrangler d1 migrations apply splitexpense-dev --local
- local D1 check: repaired literal CURRENT_TIMESTAMP row and verified fresh group insert receives a real timestamp
- yarn lint
- yarn vitest run src/tests/signup.test.ts --no-file-parallelism
- pre-commit hook ran cf-worker unit suite: 15 files passed, 273 tests passed, 8 skipped