### PR TITLE
Fix Dashboard default currency handling

### DIFF
--- a/shared-types/dist/index.d.ts
+++ b/shared-types/dist/index.d.ts
@@ -425,7 +425,6 @@ export interface TypedApiClient {
 		},
 	): Promise<ApiEndpoints[K]["response"]>;
 }
-export type Currency = "USD" | "EUR" | "GBP" | "INR";
 export declare const CURRENCIES: readonly [
 	"USD",
 	"EUR",
@@ -438,6 +437,7 @@ export declare const CURRENCIES: readonly [
 	"CNY",
 	"SGD",
 ];
+export type Currency = (typeof CURRENCIES)[number];
 export declare const GroupBudgetDataSchema: z.ZodObject<
 	{
 		id: z.ZodString;
@@ -609,7 +609,13 @@ export declare const DashboardCoreFieldsSchema: z.ZodObject<
 			USD: "USD";
 			EUR: "EUR";
 			GBP: "GBP";
+			INR: "INR";
 			CAD: "CAD";
+			AUD: "AUD";
+			JPY: "JPY";
+			CHF: "CHF";
+			CNY: "CNY";
+			SGD: "SGD";
 		}>;
 	},
 	z.core.$strip
@@ -656,7 +662,13 @@ export declare const DashboardFormSchema: z.ZodObject<
 			USD: "USD";
 			EUR: "EUR";
 			GBP: "GBP";
+			INR: "INR";
 			CAD: "CAD";
+			AUD: "AUD";
+			JPY: "JPY";
+			CHF: "CHF";
+			CNY: "CNY";
+			SGD: "SGD";
 		}>;
 		paidBy: z.ZodOptional<z.ZodString>;
 		users: z.ZodOptional<

--- a/shared-types/dist/index.js
+++ b/shared-types/dist/index.js
@@ -107,7 +107,7 @@ export const DashboardCoreFieldsSchema = z.object({
         .min(2, "Description must be at least 2 characters")
         .max(100, "Description cannot exceed 100 characters")
         .trim(),
-    currency: z.enum(["USD", "EUR", "GBP", "CAD"]),
+    currency: z.enum(CURRENCIES),
 });
 // Dashboard expense-specific fields
 export const DashboardExpenseFieldsSchema = z.object({

--- a/shared-types/index.ts
+++ b/shared-types/index.ts
@@ -472,9 +472,6 @@ export interface TypedApiClient {
 	): Promise<ApiEndpoints[K]["response"]>;
 }
 
-// Types
-export type Currency = "USD" | "EUR" | "GBP" | "INR";
-
 // Constants
 export const CURRENCIES = [
 	"USD",
@@ -488,6 +485,9 @@ export const CURRENCIES = [
 	"CNY",
 	"SGD",
 ] as const;
+
+// Types
+export type Currency = (typeof CURRENCIES)[number];
 
 // Group Budget Data Schema
 export const GroupBudgetDataSchema = z.object({
@@ -718,7 +718,7 @@ export const DashboardCoreFieldsSchema = z.object({
 		.min(2, "Description must be at least 2 characters")
 		.max(100, "Description cannot exceed 100 characters")
 		.trim(),
-	currency: z.enum(["USD", "EUR", "GBP", "CAD"]),
+	currency: z.enum(CURRENCIES),
 });
 
 // Dashboard expense-specific fields

--- a/src/pages/Dashboard/FormFields.tsx
+++ b/src/pages/Dashboard/FormFields.tsx
@@ -6,7 +6,8 @@ import {
 } from "@/components/Form/Layout";
 import { SelectBudget } from "@/SelectBudget";
 import { CreditDebit } from "./CreditDebit";
-import type { DashboardUser } from "split-expense-shared-types";
+import { CURRENCIES } from "split-expense-shared-types";
+import type { Currency, DashboardUser } from "split-expense-shared-types";
 
 interface FormFieldsProps {
 	form: any;
@@ -129,9 +130,7 @@ export function CurrencyField({
 					<Select
 						value={field.state.value}
 						onChange={(e) =>
-							field.handleChange(
-								e.target.value as "USD" | "EUR" | "GBP" | "CAD",
-							)
+							field.handleChange(e.target.value as Currency)
 						}
 						className="currency-select"
 						name="currency"
@@ -140,10 +139,11 @@ export function CurrencyField({
 						required
 						title="Please select a currency"
 					>
-						<option value="USD">USD</option>
-						<option value="EUR">EUR</option>
-						<option value="GBP">GBP</option>
-						<option value="CAD">CAD</option>
+						{CURRENCIES.map((currency) => (
+							<option key={currency} value={currency}>
+								{currency}
+							</option>
+						))}
 					</Select>
 				)}
 			</form.Field>

--- a/src/pages/Dashboard/helpers.test.ts
+++ b/src/pages/Dashboard/helpers.test.ts
@@ -1,0 +1,45 @@
+import { DashboardFormSchema } from "split-expense-shared-types";
+import { buildDefaultFormValues, getDefaultCurrency } from "./helpers";
+
+describe("Dashboard helpers", () => {
+	it("honours INR as a supported group default currency", () => {
+		expect(getDefaultCurrency("INR")).toBe("INR");
+
+		const values = buildDefaultFormValues(
+			{
+				extra: {
+					currentUser: { id: "user-1" },
+					usersById: {
+						"user-1": {
+							id: "user-1",
+							firstName: "Alice",
+						},
+					},
+					group: {
+						metadata: {
+							defaultCurrency: "INR",
+							defaultShare: { "user-1": 100 },
+						},
+					},
+				},
+			} as any,
+			[],
+		);
+
+		expect(values.currency).toBe("INR");
+	});
+
+	it("validates dashboard submissions with any supported currency", () => {
+		const result = DashboardFormSchema.safeParse({
+			addExpense: true,
+			updateBudget: false,
+			amount: 100,
+			description: "Dinner",
+			currency: "INR",
+			paidBy: "user-1",
+			users: [{ Id: "user-1", FirstName: "Alice", percentage: 100 }],
+		});
+
+		expect(result.success).toBe(true);
+	});
+});

--- a/src/pages/Dashboard/helpers.ts
+++ b/src/pages/Dashboard/helpers.ts
@@ -1,12 +1,15 @@
-import type { DashboardUser, ReduxState } from "split-expense-shared-types";
+import { CURRENCIES } from "split-expense-shared-types";
+import type {
+	Currency,
+	DashboardUser,
+	ReduxState,
+} from "split-expense-shared-types";
 import type { DashboardFormInput } from "split-expense-shared-types";
 
-export function getDefaultCurrency(
-	sessionCurrency?: string,
-): "USD" | "EUR" | "GBP" | "CAD" {
+export function getDefaultCurrency(sessionCurrency?: string): Currency {
 	return sessionCurrency &&
-		["USD", "EUR", "GBP", "CAD"].includes(sessionCurrency)
-		? (sessionCurrency as "USD" | "EUR" | "GBP" | "CAD")
+		(CURRENCIES as readonly string[]).includes(sessionCurrency)
+		? (sessionCurrency as Currency)
 		: "USD";
 }
 


### PR DESCRIPTION
## Summary
- use the shared supported currency list for Dashboard defaults, validation, and the currency select
- allow Dashboard form validation to accept INR and the other currencies already supported in Settings
- add focused tests for INR default currency behavior

## Root cause
Settings saved INR correctly, but Dashboard had a separate hard-coded currency list limited to USD/EUR/GBP/CAD. getDefaultCurrency rejected INR and fell back to USD.

## Verification
- yarn lint
- CI=true yarn test --watchAll=false --watchman=false src/pages/Dashboard/helpers.test.ts
- pre-commit hook ran cf-worker unit suite: 15 files passed, 273 tests passed, 8 skipped